### PR TITLE
Use exact rational time in Clock

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -159,6 +159,7 @@ parsetypealias(type) = type
 parsetypealias(::Val{:int}, _) = :Int64
 parsetypealias(::Val{:uint}, _) = :UInt64
 parsetypealias(::Val{:float}, _) = :Float64
+parsetypealias(::Val{:rational}, _) = :($C.Rational{Int64})
 parsetypealias(::Val{:bool}, _) = :Bool
 parsetypealias(::Val{:sym}, _) = :Symbol
 parsetypealias(::Val{:str}, _) = :String
@@ -789,6 +790,8 @@ gendefault(v::VarInfo, ::Val) = gendefaultvalue(v)
 
 gensample(v::VarInfo, x) = @q $C.sample($x)
 genunitfy(v::VarInfo, x) = begin
+    N = gettag(v, :_type)
+    x = @q $C.exactify($N, $x)
     u = gettag(v, :unit)
     isnothing(u) ? x : @q $C.unitfy($x, $C.value($u))
 end

--- a/src/state/accumulate.jl
+++ b/src/state/accumulate.jl
@@ -11,8 +11,8 @@ Accumulate(; unit, time, timeunit, _value, _type, _...) = begin
     v = _value
     #V = promote_type(V, typeof(v))
     TU = value(timeunit)
-    t = unitfy(value(time), TU)
-    T = typeof(t)
+    T = valuetype(Float64, TU)
+    t = convertvalue(T, unitfy(value(time), TU))
     RU = rateunittype(U, TU)
     R = valuetype(_type, RU)
     Accumulate{V,T,R}(v, t, zero(R), false)
@@ -51,7 +51,10 @@ genupdate(v::VarInfo, ::Val{:Accumulate}, ::MainStep; kw...) = begin
     @gensym s a0 t t0 a
     @q let $s = $(symstate(v)),
            $a0 = $s.reset ? $(gendefault(v)) : $s.value,
-           $t = $C.value($(gettag(v, :time))),
+           $t = $C.convertvalue(
+               typeof($s.time),
+               $C.unitfy($C.value($(gettag(v, :time))), $C.unittype($s.time)),
+           ),
            $t0 = $s.time,
            $a = $a0 + $s.rate * ($t - $t0)
         $(genstore(v, a; unitfy=false, minmax=true, round=false, when=false))

--- a/src/state/advance.jl
+++ b/src/state/advance.jl
@@ -7,8 +7,8 @@ end
 Advance(; init=nothing, step=nothing, unit, _type, _...) = begin
     U = value(unit)
     T = valuetype(_type, U)
-    t = isnothing(init) ? zero(T) : unitfy(value(init), U)
-    Δt = isnothing(step) ? oneunit(T) : unitfy(value(step), U)
+    t = isnothing(init) ? zero(T) : convertvalue(T, unitfy(exactify(_type, value(init)), U))
+    Δt = isnothing(step) ? oneunit(T) : convertvalue(T, unitfy(exactify(_type, value(step)), U))
     #T = promote_type(typeof(t), typeof(Δt))
     Advance{T}(t, t, Δt)
 end

--- a/src/state/capture.jl
+++ b/src/state/capture.jl
@@ -10,8 +10,8 @@ Capture(; unit, time, timeunit, _type, _...) = begin
     v = unitfy(zero(_type), U)
     #V = promote_type(V, typeof(v))
     TU = value(timeunit)
-    t = unitfy(value(time), TU)
-    T = typeof(t)
+    T = valuetype(Float64, TU)
+    t = convertvalue(T, unitfy(value(time), TU))
     RU = rateunittype(U, TU)
     R = valuetype(_type, RU)
     Capture{V,T,R}(v, t, zero(R))
@@ -41,7 +41,10 @@ gendefault(v::VarInfo, ::Val{:Capture}) = nothing
 genupdate(v::VarInfo, ::Val{:Capture}, ::MainStep; kw...) = begin
     @gensym s t t0 d
     @q let $s = $(symstate(v)),
-           $t = $C.value($(gettag(v, :time))),
+           $t = $C.convertvalue(
+               typeof($s.time),
+               $C.unitfy($C.value($(gettag(v, :time))), $C.unittype($s.time)),
+           ),
            $t0 = $s.time,
            $d = $s.rate * ($t - $t0)
         $C.store!($s, $d)
@@ -53,7 +56,10 @@ genupdate(v::VarInfo, ::Val{:Capture}, ::PostStep; kw...) = begin
     f = isnothing(w) ? genbody(v) : @q $C.value($w) ? $(genbody(v)) : zero($(gettag(v, :_type)))
     @gensym s t r
     @q let $s = $(symstate(v)),
-           $t = $C.value($(gettag(v, :time))),
+           $t = $C.convertvalue(
+               typeof($s.time),
+               $C.unitfy($C.value($(gettag(v, :time))), $C.unittype($s.time)),
+           ),
            $r = $C.unitfy($f, $C.rateunit($s))
         $s.time = $t
         $s.rate = $r

--- a/src/state/provide.jl
+++ b/src/state/provide.jl
@@ -11,9 +11,19 @@ Provide(; index, init, step, autounit, _value, _type, _...) = begin
     Δt = value(step)
     df = DataFrame(_value isa String ? CSV.File(_value) : _value)
     df = autounit ? unitfy(df) : df
-    v = filter!(r -> r[i] >= t && iszero(typeof(Δt)(r[i] - t) % Δt), df)
+    if t isa Number && Δt isa Number && typeof(Δt) <: Union{Rational,Quantity{<:Rational}}
+        N = Δt isa Quantity ? typeof(Unitful.ustrip(Δt)) : typeof(Δt)
+        t = exactify(N, t)
+        c = df[!, i]
+        if any(hasfloatvalue, c)
+            @warn "floating-point time-series index converted to exact rational values" index=i
+        end
+        df[!, i] = [exactify(N, x; warn=false) for x in c]
+    end
+    delta(x) = convertvalue(typeof(Δt), x; warn=false)
+    v = filter!(r -> r[i] >= t && iszero(delta(r[i] - t) % Δt), df)
     v[1, i] != t && error("incompatible index for initial time = $t\n$v")
-    !all(isequal(Δt), diff(v[!, i])) && error("incompatible index for time step = $Δt\n$v")
+    !all(isequal(Δt), delta.(diff(v[!, i]))) && error("incompatible index for time step = $Δt\n$v")
     V = _type
     Provide{V}(v)
 end

--- a/src/system/clock.jl
+++ b/src/system/clock.jl
@@ -3,9 +3,9 @@ timeunit(::Type{<:Clock}) = u"hr"
 @system Clock{timeunit = timeunit(Clock)} begin
     context ~ ::Nothing
     config ~ ::Config(override)
-    init => 0 ~ preserve(unit=timeunit, parameter)
-    step => 1 ~ preserve(unit=timeunit, parameter)
-    time => nothing ~ advance(init=init, step=step, unit=timeunit)
+    init => 0 ~ preserve::rational(unit=timeunit, parameter)
+    step => 1 ~ preserve::rational(unit=timeunit, parameter)
+    time => nothing ~ advance::rational(init=init, step=step, unit=timeunit)
     tick => nothing ~ advance::int
 end
 

--- a/src/unit.jl
+++ b/src/unit.jl
@@ -1,6 +1,43 @@
 using Unitful: Unitful, Units, Quantity, @u_str
 export @u_str
 
+exactify(::Type, v; warn=true) = v
+exactify(::Type{Rational{I}}, v::Integer; warn=true) where {I<:Integer} = convert(Rational{I}, v)
+exactify(::Type{Rational{I}}, v::Rational; warn=true) where {I<:Integer} = convert(Rational{I}, v)
+exactify(::Type{Rational{I}}, v::AbstractFloat; warn=true) where {I<:Integer} = begin
+    isfinite(v) || throw(ArgumentError("rational value must be finite: $v"))
+    r = rationalize(I, v)
+    if warn
+        literal = denominator(r) == 1 ? string(numerator(r)) : "$(numerator(r))//$(denominator(r))"
+        @warn "floating-point value converted to an exact rational value; use an integer or rational literal to avoid this warning" value=v rational=r literal
+    end
+    r
+end
+exactify(::Type{Rational{I}}, v::Quantity{F}; warn=true) where {I<:Integer,F<:AbstractFloat} = begin
+    x = Unitful.ustrip(v)
+    isfinite(x) || throw(ArgumentError("rational value must be finite: $v"))
+    r = rationalize(I, x)
+    u = Unitful.unit(v)
+    q = r * u
+    if warn
+        literal = denominator(r) == 1 ? "$(numerator(r))u\"$u\"" : "($(numerator(r))//$(denominator(r)))u\"$u\""
+        @warn "floating-point value converted to an exact rational value; use an integer or rational literal to avoid this warning" value=v rational=q literal
+    end
+    q
+end
+exactify(T::Type{<:Rational}, v::Quantity; warn=true) = exactify(T, Unitful.ustrip(v); warn) * Unitful.unit(v)
+
+convertvalue(::Type{T}, v; warn=true) where {T} = convert(T, v)
+convertvalue(::Type{Rational{I}}, v; warn=true) where {I<:Integer} = exactify(Rational{I}, v; warn)
+convertvalue(::Type{Q}, v; warn=true) where {I<:Integer,D,U,Q<:Quantity{Rational{I},D,U}} = begin
+    x = exactify(Rational{I}, v; warn)
+    convert(Q, unitfy(x, Unitful.unit(Q)))
+end
+
+hasfloatvalue(v::AbstractFloat) = true
+hasfloatvalue(v::Quantity) = hasfloatvalue(Unitful.ustrip(v))
+hasfloatvalue(v) = false
+
 unitfy(::Nothing, u) = nothing
 unitfy(::Nothing, ::Nothing) = nothing
 unitfy(::Missing, u) = missing

--- a/src/util/calibrate.jl
+++ b/src/util/calibrate.jl
@@ -46,6 +46,11 @@ normalize!(dfs::DataFrame...; on) = begin
     end
 end
 
+indexequal(a, b) = isequal(a, b)
+indexequal(a::Number, b::Number) = isequal(promote(a, b)...)
+indexequal(a::Tuple, b::Tuple) = length(a) == length(b) && all(indexequal(x, y) for (x, y) in zip(a, b))
+indexcontains(x, xs) = any(y -> indexequal(x, y), xs)
+
 """
     calibrate(S, obs; <keyword arguments>) -> Config | OrderedDict
 
@@ -119,7 +124,7 @@ calibrate(S::Type{<:System}, obs::DataFrame, configs::Vector; index=nothing, tar
     metric = metricfunc(metric)
     IC = [t for t in zip(getproperty.(Ref(obs), I)...)]
     IV = parseindex(index, S) |> values |> Tuple
-    snap(s) = getproperty.(s, IV) .|> value in IC
+    snap(s) = indexcontains(getproperty.(s, IV) .|> value, IC)
     NT = DataFrames.make_unique([propertynames(obs)..., T...], makeunique=true)
     T1 = NT[end-n+1:end]
     residual(c) = begin

--- a/src/util/evaluate.jl
+++ b/src/util/evaluate.jl
@@ -61,7 +61,7 @@ evaluate(S::Type{<:System}, obs, configs; index=nothing, target, metric=nothing,
     metric = metricfunc(metric)
     IC = [t for t in zip(getproperty.(Ref(obs), I)...)]
     IV = parseindex(index, S) |> values |> Tuple
-    snap(s) = getproperty.(s, IV) .|> value in IC
+    snap(s) = indexcontains(getproperty.(s, IV) .|> value, IC)
     NT = DataFrames.make_unique([propertynames(obs)..., T...], makeunique=true)
     T1 = NT[end-n+1:end]
     residual(c) = begin

--- a/src/util/simulate.jl
+++ b/src/util/simulate.jl
@@ -121,8 +121,10 @@ progress!(s::System, M::Vector{Simulation}; stop=nothing, snap=nothing, snatch=n
     snapprobe(a::Quantity) = s -> let c = s.context.clock; (c.time' - c.init') % a |> iszero end
     snapprobe(a) = probe(a)
 
-    stop = stopprobe(stop)
-    snap = snapprobe(snap)
+    clocktimeinput(v::Quantity) = convertvalue(typeof(value(s.context.clock.time)), v)
+    clocktimeinput(v) = v
+    stop = stopprobe(clocktimeinput(stop))
+    snap = snapprobe(clocktimeinput(snap))
     snatch = isnothing(snatch) ? (D, s) -> nothing : snatch
     callback = isnothing(callback) ? (s, m) -> nothing : callback
 

--- a/test/examples/soil.jl
+++ b/test/examples/soil.jl
@@ -201,7 +201,7 @@ end
 #TODO: support convenient way to set up custom Clock
 #TODO: support unit reference again?
 @system SoilClock(Clock) <: Clock begin
-    step => 15u"minute" ~ preserve(u"hr", parameter)
+    step => 15u"minute" ~ preserve::rational(u"hr", parameter)
 end
 @system SoilContext(Context) <: Context begin
     context ~ ::Context(override)

--- a/test/framework/macro.jl
+++ b/test/framework/macro.jl
@@ -133,6 +133,7 @@
             a => -1 ~ preserve::int
             b => 1 ~ preserve::uint
             c => 1 ~ preserve::float
+            r => 1//10 ~ preserve::rational
             d => true ~ preserve::bool
             e => :a ~ preserve::sym
             f => "A" ~ preserve::str
@@ -145,6 +146,7 @@
         @test s.a' isa Int64 && s.a' === -1
         @test s.b' isa UInt64 && s.b' == 1
         @test s.c' isa Float64 && s.c' === 1.0
+        @test s.r' isa Rational{Int64} && s.r' === 1//10
         @test s.d' isa Bool && s.d' === true
         @test s.e' isa Symbol && s.e' === :a
         @test s.f' isa String && s.f' === "A"

--- a/test/framework/state/accumulate.jl
+++ b/test/framework/state/accumulate.jl
@@ -65,6 +65,20 @@
         @test s.a' == 1 && s.b' == 6 && s.c' == 3
     end
 
+    @testset "rational clock integration" begin
+        @system SAccumulateRationalClock(Controller) begin
+            a => 1 ~ accumulate
+        end
+        s = instance(SAccumulateRationalClock; config=:Clock => (:step => 10u"minute"))
+        @test s.a.time == 0u"hr"
+        @test s.a.time isa Cropbox.Quantity{Float64}
+        for _ in 1:6
+            update!(s)
+        end
+        @test s.a.time == 1u"hr"
+        @test s.a' ≈ 1
+    end
+
     @testset "unit hour" begin
         @system SAccumulateUnitHour(Controller) begin
             a => 1 ~ accumulate(u"hr")

--- a/test/framework/state/capture.jl
+++ b/test/framework/state/capture.jl
@@ -28,6 +28,20 @@
         @test s.b' == 4 && s.c' == 8
     end
 
+    @testset "rational clock interval" begin
+        @system SCaptureRationalClock(Controller) begin
+            a => 1 ~ capture
+        end
+        s = instance(SCaptureRationalClock; config=:Clock => (:step => 10u"minute"))
+        @test s.a.time == 0u"hr"
+        @test s.a.time isa Cropbox.Quantity{Float64}
+        for _ in 1:6
+            update!(s)
+        end
+        @test s.a.time == 1u"hr"
+        @test s.a' ≈ 1//6
+    end
+
     @testset "unit hour" begin
         @system SCaptureUnitHour(Controller) begin
             a => 1 ~ capture(u"hr")

--- a/test/framework/state/provide.jl
+++ b/test/framework/state/provide.jl
@@ -43,6 +43,19 @@ using TimeZones
         @test_throws ErrorException instance(SProvideTime)
     end
 
+    @testset "floating-point time index" begin
+        @system SProvideTimeIndex(Controller) begin
+            a => DataFrame(index=[0.0, 1/6, 1/3]u"hr", value=1:3) ~ provide
+        end
+        local s
+        @test_logs (:warn, r"floating-point time-series index converted") s = instance(
+            SProvideTimeIndex;
+            config=:Clock => (:step => 10u"minute"),
+        )
+        @test s.a'.index == [0//1, 1//6, 1//3]u"hr"
+        @test eltype(s.a'.index) <: Cropbox.Quantity{Rational{Int64}}
+    end
+
     @testset "tick" begin
         @system SProvideTick(Controller) begin
             a => DataFrame(index=0:3, value=0:10:30) ~ provide(init=context.clock.tick, step=1)

--- a/test/framework/state/track.jl
+++ b/test/framework/state/track.jl
@@ -9,6 +9,20 @@
         @test s.a' == 1 && s.b' == 2 && s.c' == 3
     end
 
+    @testset "rational clock conversion" begin
+        @system STrackRationalClock(Controller) begin
+            t(context.clock.time) ~ track::float(u"hr")
+        end
+        s = instance(STrackRationalClock; config=:Clock => (:step => 10u"minute"))
+        @test s.t' == 0u"hr"
+        @test s.t' isa Cropbox.Quantity{Float64}
+        for _ in 1:6
+            update!(s)
+        end
+        @test s.context.clock.time' === (1//1)u"hr"
+        @test s.t' == 1u"hr"
+    end
+
     @testset "cross reference" begin
         @test_throws LoadError @eval @system STrackXRef(Controller) begin
             a(b) => b ~ track

--- a/test/framework/system/calendar.jl
+++ b/test/framework/system/calendar.jl
@@ -71,4 +71,20 @@ import Dates
         s = instance(SCalendarCountSeconds; config=o)
         @test s.count' == n
     end
+
+    @testset "subhourly clock" begin
+        @system SCalendarSubhourly(Calendar, Controller)
+        t0 = ZonedDateTime(2011, 10, 29, tz"Asia/Seoul")
+        o = (
+            :Calendar => (init=t0,),
+            :Clock => (step=10u"minute",),
+        )
+        s = instance(SCalendarSubhourly; config=o)
+        for _ in 1:6
+            update!(s)
+        end
+        @test s.context.clock.time' === (1//1)u"hr"
+        @test s.time' == t0 + Dates.Hour(1)
+        @test s.date' == Dates.Date(t0)
+    end
 end

--- a/test/framework/system/clock.jl
+++ b/test/framework/system/clock.jl
@@ -2,6 +2,9 @@
     @testset "basic" begin
         @system SClock(Controller)
         s = instance(SClock)
+        @test s.context.clock.init' isa Cropbox.Quantity{Rational{Int64}}
+        @test s.context.clock.step' isa Cropbox.Quantity{Rational{Int64}}
+        @test s.context.clock.time' isa Cropbox.Quantity{Rational{Int64}}
         @test s.context.clock.time' == 0u"hr"
         @test s.context.clock.tick' === 0
         update!(s)
@@ -26,6 +29,59 @@
         @test s.context.clock.tick' === 2
     end
 
+    @testset "subhourly advance" begin
+        @system SClockSubhourly(Controller)
+        s = instance(SClockSubhourly; config=:Clock => (:step => 10u"minute"))
+        @test s.context.clock.step' === (1//6)u"hr"
+        for _ in 1:6
+            update!(s)
+        end
+        @test s.context.clock.time' === (1//1)u"hr"
+        @test s.context.clock.tick' === 6
+    end
+
+    @testset "floating-point step" begin
+        @system SClockFloatInput(Controller)
+        local whole
+        @test_logs (:warn, r"floating-point value converted") whole = instance(
+            SClockFloatInput;
+            config=:Clock => (:step => 1.0u"minute"),
+        )
+        @test whole.context.clock.step' === (1//60)u"hr"
+        local fractional
+        @test_logs (:warn, r"floating-point value converted") fractional = instance(
+            SClockFloatInput;
+            config=:Clock => (:step => 0.1u"hr"),
+        )
+        @test fractional.context.clock.step' === (1//10)u"hr"
+        @test_throws ArgumentError instance(
+            SClockFloatInput;
+            config=:Clock => (:step => Inf*u"hr"),
+        )
+    end
+
+    @testset "nested clock" begin
+        @system SSubhourlyClock(Clock) <: Clock begin
+            step => 10u"minute" ~ preserve::rational(u"hr", parameter)
+        end
+        @system SSubhourlyContext(Context) <: Context begin
+            context ~ ::Context(override)
+            clock(config) ~ ::SSubhourlyClock
+        end
+        @system SSubhourlyChild begin
+            context ~ ::SSubhourlyContext(override)
+        end
+        @system SSubhourlyParent(Controller) begin
+            child_context(context, config) ~ ::SSubhourlyContext(context)
+            child(context=child_context) ~ ::SSubhourlyChild
+        end
+        s = instance(SSubhourlyParent)
+        update!(s)
+        @test s.context.clock.time' === (1//1)u"hr"
+        @test s.child.context.clock.time' === (1//1)u"hr"
+        @test s.child.context.clock.tick' === 6
+    end
+
     @testset "daily" begin
         @system SClockDaily{Context => Cropbox.DailyContext}(Controller) begin
             a => 1 ~ accumulate
@@ -33,6 +89,7 @@
         s = instance(SClockDaily)
         @test s.context isa Cropbox.DailyContext
         @test s.context.clock isa Cropbox.DailyClock
+        @test s.context.clock.time' isa Cropbox.Quantity{Rational{Int64}}
         @test s.context.clock.time' == 0u"d"
         @test s.context.clock.tick' === 0
         update!(s)

--- a/test/framework/util.jl
+++ b/test/framework/util.jl
@@ -1,4 +1,5 @@
 @testset "util" begin
     include("util/simulate.jl")
     include("util/calibrate.jl")
+    include("util/evaluate.jl")
 end

--- a/test/framework/util/evaluate.jl
+++ b/test/framework/util/evaluate.jl
@@ -1,0 +1,19 @@
+using DataFrames
+
+@testset "evaluate" begin
+    @testset "floating-point time index" begin
+        @system SEvaluateTimeIndex(Controller) begin
+            a => 1 ~ accumulate
+        end
+        obs = DataFrame(time=[0.1]u"hr", a=[0.1])
+        e = evaluate(
+            SEvaluateTimeIndex,
+            obs;
+            config=:Clock => (:step => 6u"minute"),
+            target=:a,
+            stop=(1//10)u"hr",
+            verbose=false,
+        )
+        @test e === 0.0
+    end
+end

--- a/test/framework/util/simulate.jl
+++ b/test/framework/util/simulate.jl
@@ -49,6 +49,66 @@ using Dates
         @test r3[end, :b] == 2 * 24 * 365.25
     end
 
+    @testset "floating-point stop" begin
+        @system SSimulateFloatingStop(Controller)
+        local r
+        @test_logs (:warn, r"floating-point value converted") r = simulate(
+            SSimulateFloatingStop;
+            config=:Clock => (:step => 1u"minute"),
+            stop=0.1u"hr",
+            verbose=false,
+        )
+        @test r.time[end] === (1//10)u"hr"
+    end
+
+    @testset "floating-point snap" begin
+        @system SSimulateFloatingSnap(Controller)
+        local r
+        @test_logs (:warn, r"floating-point value converted") r = simulate(
+            SSimulateFloatingSnap;
+            config=:Clock => (:step => 1u"minute"),
+            stop=(1//10)u"hr",
+            snap=0.05u"hr",
+            verbose=false,
+        )
+        @test r.time == [0//1, 1//20, 1//10]u"hr"
+    end
+
+    @testset "off-grid stop" begin
+        @system SSimulateOffGridStop(Controller)
+        r = simulate(
+            SSimulateOffGridStop;
+            config=:Clock => (:step => 7u"minute"),
+            stop=1u"hr",
+            verbose=false,
+        )
+        @test r.time[end-1] === (14//15)u"hr"
+        @test r.time[end] === (21//20)u"hr"
+    end
+
+    @testset "subhourly timestep" begin
+        @system SSimulateSubhourly(Controller) begin
+            total => 1 ~ accumulate
+        end
+        hourly = simulate(
+            SSimulateSubhourly;
+            config=:Clock => (:step => 1u"hr"),
+            stop=1u"hr",
+            snap=1u"hr",
+            verbose=false,
+        )
+        subhourly = simulate(
+            SSimulateSubhourly;
+            config=:Clock => (:step => 10u"minute"),
+            stop=1u"hr",
+            snap=1u"hr",
+            verbose=false,
+        )
+        @test subhourly.time == hourly.time == (0:1)u"hr"
+        @test subhourly.total ≈ hourly.total
+        @test subhourly.total ≈ [0.0, 1.0]
+    end
+
     @testset "stop count" begin
         @system SSimulateStopCount(Controller) begin
             a => 1 ~ preserve(parameter)


### PR DESCRIPTION
## Summary

- add a `::rational` DSL alias backed by `Rational{Int64}` and use it for `Clock.init`, `Clock.step`, and `Clock.time`
- accept floating-point time inputs for compatibility, convert them to exact rational values, and emit a warning suggesting integer or rational literals
- keep `Accumulate` and `Capture` time arithmetic on `Float64`, while converting time-series indexes and simulation/evaluation boundaries where exact matching is required
- support sub-hourly timesteps with the standard `Clock` rather than requiring separate minute-specific Clock, Context, and Controller types

## Motivation

This was prompted by Carter's CAM photosynthesis work in LeafGasExchange.jl, which requires 1–10 minute timesteps. With hours as the base unit, repeated floating-point minute increments can miss exact hourly stop, snap, or index boundaries.

It also enables extending Nayeong's timestep-resolution analysis beyond the existing 1–168 hour range. Preliminary sub-hourly experiments had been deferred because floating-point drift made behavior inconsistent across timestep choices and complicated comparison.

Using exact rational values at the clock and time-index boundaries removes that drift without introducing a parallel minute-specific context hierarchy. Existing integer-hour configurations continue to work, while inputs such as `1u"minute"` and `(1//10)u"hr"` remain exact. Inputs such as `0.1u"hr"` are still accepted with a warning.

For a stop time that is not exactly reachable by the configured timestep, simulation retains at-or-after stop behavior.

## Validation

- focused framework tests: 378 passed, with 1 existing broken test
- soil multiple-clock example: 1 passed; final time was exactly `1920//1 hr`
- `git diff --check`

The full local suite remains non-clean because of pre-existing or environment-specific failures unrelated to this change, so the focused results are reported separately.