### PR TITLE
Fix Julia 1.12 CI failures

### DIFF
--- a/src/util/calibrate.jl
+++ b/src/util/calibrate.jl
@@ -153,9 +153,8 @@ calibrate(S::Type{<:System}, obs::DataFrame, configs::Vector; index=nothing, tar
     optim_default = (;
         MaxSteps=5000,
         TraceInterval=10,
-        RandomizeRngSeed=false,
     )
-    #HACK: always initialize random seed first on our end regardless of RandomizeRngSeed option
+    #HACK: initialize random seed before calling BlackBoxOptim
     # https://github.com/robertfeldt/BlackBoxOptim.jl/issues/158
     Random.seed!(0)
     r = BlackBoxOptim.bboptimize(cost;

--- a/test/framework/macro.jl
+++ b/test/framework/macro.jl
@@ -5,7 +5,7 @@
             __b: __bb => 2 ~ preserve
         end
         s = instance(SPrivateName)
-        @test_throws ErrorException s._a
+        @test_throws FieldAccessError s._a
         @test s.__SPrivateName__a' == 1
         @test s.__SPrivateName__aa === s.__SPrivateName__a
         @test s.__b' == 2
@@ -62,14 +62,14 @@
         end
         @eval @system SPrivateNameMixed1(SPrivateNameMixin1, SPrivateNameMixin2, Controller)
         s1 = instance(SPrivateNameMixed1)
-        @test_throws ErrorException s1._a
+        @test_throws FieldAccessError s1._a
         @test s1.__SPrivateNameMixin1__a' == 1
         @test s1.__SPrivateNameMixin2__a' == 2
         @test s1.b' == 1
         @test s1.c' == 2
         @eval @system SPrivateNameMixed11(SPrivateNameMixed1, Controller)
         s11 = instance(SPrivateNameMixed11)
-        @test_throws ErrorException s11._a
+        @test_throws FieldAccessError s11._a
         @test s11.__SPrivateNameMixin1__a' == 1
         @test s11.__SPrivateNameMixin2__a' == 2
         @test s11.b' == 1

--- a/test/framework/state/bring.jl
+++ b/test/framework/state/bring.jl
@@ -12,10 +12,10 @@
         s = instance(SBring; config=o)
         @test s.a' == s.p.a' == 1
         @test s.b' == s.p.b' == 2
-        @test_throws ErrorException s.c'
+        @test_throws FieldAccessError s.c'
         @test s.p.c' == 0
         update!(s)
-        @test_throws ErrorException s.c'
+        @test_throws FieldAccessError s.c'
         @test s.p.c' == 2
     end
 
@@ -37,10 +37,10 @@
         @test s.p === s.m.p
         @test s.m.a' == s.p.a' == 1
         @test s.m.b' == s.p.b' == 2
-        @test_throws ErrorException s.m.c'
+        @test_throws FieldAccessError s.m.c'
         @test s.p.c' == 0
         update!(s)
-        @test_throws ErrorException s.m.c'
+        @test_throws FieldAccessError s.m.c'
         @test s.p.c' == 2
     end
 
@@ -64,7 +64,7 @@
         s = instance(SBringParams; config=o)
         @test s.a' == 0
         @test s.b' == 1
-        @test_throws ErrorException s.c' == 2
+        @test_throws FieldAccessError s.c' == 2
         @test s.d' == false
         @test s.p.a' == 1
         @test s.p.b' == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Cropbox
 using Test
 
+const FieldAccessError = isdefined(Base, :FieldError) ? getfield(Base, :FieldError) : ErrorException
+
 @testset "cropbox" begin
     @testset "framework" begin
         include("framework/macro.jl")


### PR DESCRIPTION
## Summary

- Stop passing the obsolete `RandomizeRngSeed` option to BlackBoxOptim.
- Update field-access tests to expect `FieldError` on Julia 1.12 while retaining compatibility with older Julia versions.

## Why

BlackBoxOptim 0.6.9 attempts to call its removed `warn` binding when the obsolete RNG option is present. Julia 1.12 also reports field-access failures as `FieldError`, and expecting `ErrorException` becomes an error under CI's `--depwarn=error` setting.

These changes restore the stable Julia CI without changing calibration behavior or dropping support for older Julia versions.

## Testing

- Julia 1.12.6 with `--depwarn=error`
- 876 passed, 1 existing broken